### PR TITLE
Avoid "Class 'SoapClient' not found" at runtime

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,12 +12,11 @@
     "require": {
         "php" : ">=7.4",
         "ext-soap": "*",
-        "illuminate/support": "6.*|7.*|8.*",
+        "illuminate/support": "5.2.*|5.3.*|5.4.*|5.5.*|5.6.*|5.7.*|5.8.*|6.*|7.*|8.*",
+        "laravel/framework": "5.2.*|5.3.*|5.4.*|5.5.*|5.6.*|5.7.*|5.8.*|6.*|7.*|8.*",
         "phlak/semver": "^4.0"
     },
     "require-dev": {
-        "illuminate/support": "5.2.*|5.3.*|5.4.*|5.5.*|5.6.*|5.7.*|5.8.*|6.*|7.*|8.*",
-        "laravel/framework": "5.2.*|5.3.*|5.4.*|5.5.*|5.6.*|5.7.*|5.8.*|6.*|7.*|8.*",
         "phpunit/phpunit": "^9.3@dev",
         "orchestra/testbench": "3.8.*|4.*|5.*|6.*"
     },

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
+        "ext-soap": "*",
         "illuminate/support": "6.*|7.*|8.*",
         "phlak/semver": "^4.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -10,12 +10,12 @@
     ],
     "minimum-stability": "dev",
     "require": {
+        "php" : ">=7.4",
         "ext-soap": "*",
         "illuminate/support": "6.*|7.*|8.*",
         "phlak/semver": "^4.0"
     },
     "require-dev": {
-        "php" : ">=7.4",
         "illuminate/support": "5.2.*|5.3.*|5.4.*|5.5.*|5.6.*|5.7.*|5.8.*|6.*|7.*|8.*",
         "laravel/framework": "5.2.*|5.3.*|5.4.*|5.5.*|5.6.*|5.7.*|5.8.*|6.*|7.*|8.*",
         "phpunit/phpunit": "^9.3@dev",


### PR DESCRIPTION
To avoid the error "Class 'SoapClient' not found" at runtime, add PHP extension SOAP to requirements. This warns about missing SOAP extension at package installation with `composer require ambersive/vatvalidator`.

Also, move some base requirements from `require-dev` to `require`.